### PR TITLE
fix: iOS perf monitor interaction

### DIFF
--- a/ios/RNSplashScreen.m
+++ b/ios/RNSplashScreen.m
@@ -40,7 +40,7 @@ NSInteger const RNSplashScreenOverlayTag = 39293;
   UIImageView *imageView = (UIImageView *)[subviews.lastObject viewWithTag:RNSplashScreenOverlayTag];
 
   #ifdef DEBUG
-  if (imageView == nil) {
+  if (imageView == nil && subviews.count > 1) {
     // Allows the SplashScreen to be removed even when the perf monitor is the last subview.
     imageView = (UIImageView *)[subviews[subviews.count - 2] viewWithTag:RNSplashScreenOverlayTag];
   }

--- a/ios/RNSplashScreen.m
+++ b/ios/RNSplashScreen.m
@@ -41,6 +41,7 @@ NSInteger const RNSplashScreenOverlayTag = 39293;
 
   #ifdef DEBUG
   if (imageView == nil) {
+    // Allows the SplashScreen to be removed even when the perf monitor is the last subview.
     imageView = (UIImageView *)[subviews[subviews.count - 2] viewWithTag:RNSplashScreenOverlayTag];
   }
   #endif

--- a/ios/RNSplashScreen.m
+++ b/ios/RNSplashScreen.m
@@ -36,11 +36,12 @@ NSInteger const RNSplashScreenOverlayTag = 39293;
 + (void)hide {
   // let's try to hide, even if showing == false, ...just in case
 
-  UIImageView *imageView = (UIImageView *)[UIApplication.sharedApplication.keyWindow.subviews.lastObject viewWithTag:RNSplashScreenOverlayTag];
+  NSArray *subviews = UIApplication.sharedApplication.keyWindow.subviews;
+  UIImageView *imageView = (UIImageView *)[subviews.lastObject viewWithTag:RNSplashScreenOverlayTag];
 
   #ifdef DEBUG
   if (imageView == nil) {
-    imageView = (UIImageView *)[UIApplication.sharedApplication.keyWindow.subviews[UIApplication.sharedApplication.keyWindow.subviews.count - 2] viewWithTag:RNSplashScreenOverlayTag];
+    imageView = (UIImageView *)[subviews[subviews.count - 2] viewWithTag:RNSplashScreenOverlayTag];
   }
   #endif
 

--- a/ios/RNSplashScreen.m
+++ b/ios/RNSplashScreen.m
@@ -37,6 +37,13 @@ NSInteger const RNSplashScreenOverlayTag = 39293;
   // let's try to hide, even if showing == false, ...just in case
 
   UIImageView *imageView = (UIImageView *)[UIApplication.sharedApplication.keyWindow.subviews.lastObject viewWithTag:RNSplashScreenOverlayTag];
+
+  #ifdef DEBUG
+  if (imageView == nil) {
+    imageView = (UIImageView *)[UIApplication.sharedApplication.keyWindow.subviews[UIApplication.sharedApplication.keyWindow.subviews.count - 2] viewWithTag:RNSplashScreenOverlayTag];
+  }
+  #endif
+
   if (imageView != nil) {
     [imageView removeFromSuperview];
   }


### PR DESCRIPTION
Allows the `SplashScreen` to be removed even when the perf monitor is the last subview.