### PR TITLE
chore: don't show native Android error on video playback error

### DIFF
--- a/android/src/main/java/org/devio/rn/splashscreen/SplashScreen.java
+++ b/android/src/main/java/org/devio/rn/splashscreen/SplashScreen.java
@@ -112,6 +112,14 @@ public class SplashScreen {
                             hideVideo(activity);
                         }
                     });
+
+                    videoView.setOnErrorListener(new MediaPlayer.OnErrorListener() {
+                        @Override
+                        public boolean onError(MediaPlayer mp, int what, int extra) {
+                            Log.d("splashscreen video", "onError" + Integer.toString(what) + ", " + Integer.toString(extra));
+                            return true;
+                        }
+                    });
                 }
             }
         });

--- a/android/src/main/java/org/devio/rn/splashscreen/SplashScreen.java
+++ b/android/src/main/java/org/devio/rn/splashscreen/SplashScreen.java
@@ -117,6 +117,7 @@ public class SplashScreen {
                         @Override
                         public boolean onError(MediaPlayer mp, int what, int extra) {
                             Log.d("splashscreen video", "onError" + Integer.toString(what) + ", " + Integer.toString(extra));
+                            hideVideo(activity);
                             return true;
                         }
                     });


### PR DESCRIPTION
Ignore error so users don't get native alert. Wasn't able to find a stable repro of the video issue (I did see it a few times in dev though)